### PR TITLE
Fixed type of ValidationError

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -22,6 +22,6 @@ declare module "express-json-validator-middleware" {
 	}
 
 	export class ValidationError extends Error {
-		public validationErrors: List<ErrorObject>;
+		public validationErrors: List<ErrorObject[]>;
 	}
 }


### PR DESCRIPTION
The value in the validationError property is an array. The code in 

https://github.com/vacekj/express-json-validator-middleware/blob/51347090002a19048016d0512c26439e8a642e41/src/index.js#L56 

puts validationFunction.errors in there which according to 

https://github.com/ajv-validator/ajv/blob/11e997bda2f3eecb445c1e5a07d96ef7e81c5f5d/lib/ajv.d.ts#L158

is an Array