### PR TITLE
Bump package version from 2.1.0 to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "express-json-validator-middleware",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"description": "An Express middleware to validate requests against JSON Schemas",
 	"main": "src/index.js",
 	"author": "Josef Vacek",


### PR DESCRIPTION
This brings things in sync with the version which was published to npm on 2020-03-27.

https://github.com/vacekj/express-json-validator-middleware/tree/v2.1.1

Fixes #57.