### PR TITLE
Use the right type for the ValidationError constructor

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -22,6 +22,7 @@ declare module "express-json-validator-middleware" {
 	}
 
 	export class ValidationError extends Error {
+		constructor(validationErrors: List<ErrorObject[]>);
 		public validationErrors: List<ErrorObject[]>;
 	}
 }


### PR DESCRIPTION
The current `ValidationError` constructor definition is inherited from the base `Error`, which gives it a signature of `constructor(message?: string, fileName?: string, lineNumber?: string)`. This is at odds with the actual definition and use of `ValidationError`, which means TypeScript consumers of this library that wish to use this error themselves must currently work around the issue like so:
```
throw new ValidationError({body: errors} as any);
```